### PR TITLE
Fix for issue #54

### DIFF
--- a/epson_print_conf.py
+++ b/epson_print_conf.py
@@ -2926,7 +2926,7 @@ if __name__ == "__main__":
                         print(
                             f"EEPROM_ADDR {hex(addr).rjust(4)} = "
                             f"{str(addr).rjust(3)}: "
-                            f"{int(val):#04x} = {val.rjust(3)}"
+                            f"0x{val.rjust(2)} = {int(val,16)}"
                         )
                 except (ValueError, SyntaxError):
                     print("invalid argument for read_eeprom")


### PR DESCRIPTION
This fixes a formatting error when values read from EEPROM are greater or equal than 0x0A.