### PR TITLE
Add asyncio event loop initialization

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -17,6 +17,9 @@ import logging
 import webbrowser
 import pickle
 
+import asyncio
+asyncio.set_event_loop(asyncio.new_event_loop())
+
 from code import InteractiveConsole
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO


### PR DESCRIPTION
Fix bug "There is no current event loop in thread 'MainThread'" on Mac with the latest Python version 3.14.3