### PR TITLE
Add L365 printer profile with validated waste counter mapping

### DIFF
--- a/epson_print_conf.py
+++ b/epson_print_conf.py
@@ -221,6 +221,22 @@ class EpsonPrinter:
             },
             "serial_number": range(192, 202),
         },
+        "L365": {
+            "read_key": [130, 2],
+            "write_key": b"Gerbera*",
+            # L365 reports realistic main waste level with 16-bit counter (24,25).
+            # Address 30 exists and is still reset in raw_waste_reset.
+            "main_waste": {"oids": [24, 25], "divider": 62.07},
+            "raw_waste_reset": {24: 0, 25: 0, 30: 0, 28: 0, 29: 0, 46: 94},
+            "stats": {
+                "Ink replacement counter - Black": [242],
+                "Ink replacement counter - Yellow": [243],
+                "Ink replacement counter - Cyan": [244],
+                "Ink replacement counter - Magenta": [245],
+                "Maintenance required level of 1st waste ink counter": [46],
+            },
+            "serial_number": range(192, 202),
+        },
         "L366": {
             "read_key": [130, 2],
             "write_key": b'Gerbera*',


### PR DESCRIPTION
## Summary

- Add Epson **L365** profile to `PRINTER_CONFIG` so the model appears in the UI dropdown and can be selected.
- Keep official L365 keys/counters from parser reference and add validated mapping for reset/stats/serial.
- Adjust `main_waste` reading to use 16-bit counter (`oids [24, 25]`) for accurate percentage calculation on real hardware in the current implementation.

## Real device validation (Epson L365)

Validated against a real **Epson L365 Series** over network SNMP/LPR:

- Printer discovery identifies the device as `EPSON L365 Series`.
- CLI info/status works:
  - `get_serial_number`
  - `get_stats`
  - `get_waste_ink_levels`
  - `get_printer_status`
- EEPROM mapping checks performed:
  - serial range (`192..201`) decodes correctly
  - stats counters (`242..245`, `46`) match `get_stats` output
  - waste addresses (`24`, `25`, `30`, `46`) read successfully
- Reset paths validated safely with dry-run:
  - `--reset_waste_ink --dry-run`
  - `--temp_reset_waste_ink --dry-run`
- Windows build regenerated with PyInstaller and model list source validated (`L365` present in `valid_printers` used by UI dropdown).

## Notes

- Parser reference includes `main_waste` as `[24, 25, 30]` plus filter metadata.
- In this codebase, using `[24, 25]` produced consistent real-device percentages, while including `30` can inflate the computed value.

Fixes #111