### PR TITLE
Add XP-320 support

### DIFF
--- a/epson_print_conf.py
+++ b/epson_print_conf.py
@@ -562,6 +562,11 @@ class EpsonPrinter:
             },
             "last_printer_fatal_errors": [60, 203, 204, 205, 206, 0x01d3],
         },
+        "XP-320": {
+            "read_key": [85, 5],
+            "write_key": b'Muscari.',
+            "same-as": "XP-315"
+        },
         "XP-342": {
             "alias": ["XP-343", "XP-345"],
             "read_key": [1, 5],


### PR DESCRIPTION
## Summary

Adds support for the Epson **XP-320** (North American model) as a new entry inheriting from `XP-315` via `same-as`, with model-specific keys.

## Keys
- `read_key`: `[85, 5]`
- `write_key`: `Muscari.`

## How verified
Tested live against a physical XP-320 (firmware `SJ11J1 11 Jan 2019`):
- `read_key` discovered via `--detect-key`
- `write_key` confirmed by successful `--reset_waste_ink`: `main_waste` went from 57.96% → 0%
- All inherited `XP-315` features work against the XP-320: stats, serial number, printer head ID, cartridges, ink replacement counters, fatal error log, waste-ink query/reset

## Test plan
- [x] `--detect-key` finds `[85, 5]`
- [x] `-q stats` returns valid decoded data
- [x] `-q get_serial_number`, `get_printer_head_id`, `get_firmware_version`, `get_cartridges`, `get_ink_replacement_counters`, `get_last_printer_fatal_errors` all return valid data
- [x] `--reset_waste_ink --dry-run` shows expected EEPROM writes
- [x] `--reset_waste_ink` zeros raw EEPROM addresses 24, 25, 28, 29 (confirmed via `-R`)