### PR TITLE
Add nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,49 @@ To print data to Epson printers via LPR, it also uses the [epson_escp2](https://
 
 It is tested with Ubuntu / Windows Subsystem for Linux, Windows.
 
+### Nix Flake
+The program can be run using Nix flakes with:
+```sh
+nix run github:Ircama/epson_print_conf
+```
+For the GUI:
+```sh
+nix run github:Ircama/epson_print_conf#ui
+```
+
+
+Or installed on a flakes system:
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    epson-print-conf = {
+      url = "github:Ircama/epson_print_conf";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  }
+
+  outputs = { nixpkgs, epson-print-conf, ... }: {
+    nixosConfigurations.<system-name> = nixpkgs.lib.nixosSystem {
+      modules = [
+        {
+          environment.systemPackages = [ epson-print-conf ];
+        }
+      ];
+    };
+  };
+}
+```
+The programs from this repository are then available as:
+```sh
+epson_print_conf
+epson_print_conf_ui
+epson_print_conf_find_printers
+epson_print_conf_parse_devices
+```
+
+
+
 ## Usage
 
 ### Running the pre-built GUI executable code

--- a/dependencies.nix
+++ b/dependencies.nix
@@ -1,0 +1,111 @@
+{
+  babel,
+  buildPythonPackage,
+  colorama,
+  fetchFromGitHub,
+  fetchPypi,
+  pillow,
+  pysnmp,
+  pyyaml,
+  setuptools,
+}:
+rec {
+  pysnmp-sync-adapter = buildPythonPackage (finalAttrs: {
+    pname = "pysnmp_sync_adapter";
+    version = "1.0.8";
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-uNd8MOxwOsbMLG9PkFzLchi8rG/RIPX1dK+U3ar1aPY=";
+    };
+
+    dependencies = [ pysnmp ];
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+
+  text-console = buildPythonPackage (finalAttrs: {
+    pname = "text_console";
+    version = "2.0.7";
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-DmhLZOaklqLa/7evJCxZ5m/JSsRkGgSmjFC0XtVT4BM=";
+    };
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+
+  tkcalendar = buildPythonPackage (finalAttrs: {
+    pname = "tkcalendar";
+    version = "1.6.1";
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-Xt+VjApZQp6QMJ6bgFsuIpGSu8q5UkYCRyBNcDDupc8=";
+    };
+
+    dependencies = [ babel ];
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+
+  hexdump2 = buildPythonPackage (finalAttrs: {
+    pname = "hexdump2";
+    version = "1.2.2";
+
+    # source archive not published to pypi, use github source instead
+    src = fetchFromGitHub {
+      owner = "HGrooms";
+      repo = finalAttrs.pname;
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-ah0hqTu9zDoTQB7+HVtnbI+fw33OS7wXJLCMnjbpKUk=";
+    };
+
+    dependencies = [
+      colorama
+    ];
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+
+  pyprintlpr = buildPythonPackage (finalAttrs: {
+    pname = "pyprintlpr";
+    version = "1.0.3";
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-zcGftwTo+g+fsNdIwKUgwJ1yxyxYIA7dPofuMY9olPs=";
+    };
+
+    dependencies = [
+      hexdump2
+      pyyaml
+    ];
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+
+  epson-escp2 = buildPythonPackage (finalAttrs: {
+    pname = "epson_escp2";
+    version = "1.0.2";
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-p+Plp030tuydO3kqh5RfbwdOFRRFjOpzLreIUK3olg8=";
+    };
+
+    dependencies = [
+      pillow
+      hexdump2
+    ];
+
+    pyproject = true;
+    build-system = [ setuptools ];
+  });
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Nix Flake for epson_print_conf (Epson Printer Config)";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forEachSupportedSystem =
+        f: lib.genAttrs lib.systems.flakeExposed (system: f (import nixpkgs { inherit system; }));
+
+      mkEpsonPrintConf =
+        pkgs:
+        let
+          # modules not in nixpkgs
+          dependencyPackages = ps: ps.callPackage ./dependencies.nix { };
+
+          # python environment with all dependencies in python path
+          pythonWithPackages = pkgs.python3.withPackages (
+            ps:
+            (with ps; [
+              black
+              pyperclip
+              pysnmp
+              pyyaml
+              tkinter
+              tomli
+            ])
+            ++ (builtins.attrValues (dependencyPackages ps))
+          );
+        in
+        pythonWithPackages.pkgs.callPackage ./package.nix {
+          inherit pythonWithPackages;
+        };
+    in
+    {
+      # note that the executable scripts are prefixed with epson_print_conf (epson_print_conf, epson_print_conf_ui, epson_print_conf_parse_devices, epson_print_conf_find_printers)
+      packages = forEachSupportedSystem (pkgs: rec {
+        epson-print-conf = mkEpsonPrintConf pkgs;
+        default = epson-print-conf;
+      });
+
+      # for nix run (e.g., nix run .#ui)
+      apps = forEachSupportedSystem (
+        pkgs:
+        let
+          mkApp = name: {
+            type = "app";
+            program = lib.getExe' (mkEpsonPrintConf pkgs) name;
+          };
+        in
+        {
+          epson_print_conf = mkApp "epson_print_conf";
+          ui = mkApp "epson_print_conf_ui";
+          find_printers = mkApp "epson_print_conf_find_printers";
+          parse_devices = mkApp "epson_print_conf_parse_devices";
+        }
+      );
+
+      devShells = forEachSupportedSystem (
+        pkgs:
+        pkgs.mkShellNoCC {
+          buildInputs = [ (mkEpsonPrintConf pkgs) ];
+        }
+      );
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,54 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
+  pythonWithPackages,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "epson_print_conf";
+  version = "7.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Ircama";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kyNg/JwK0gnjOG9ppThipcyOoQlA90zeJTfWbMPmars=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    # create wrapper to run the script from the python environment
+    wrap_script() {
+      makeWrapper ${pythonWithPackages.interpreter} "$out/bin/$2" \
+        --add-flags "-m $1" \
+        --prefix PYTHONPATH : "$out/lib/${pythonWithPackages.sitePackages}"
+    }
+
+    # put the scripts as modules under site packages and create wrapper scripts to setup python environment
+    mkdir -p $out/bin $out/lib/${pythonWithPackages.sitePackages}
+    cp {epson_print_conf,ui,find_printers,parse_devices}.py $out/lib/${pythonWithPackages.sitePackages}/
+
+    # prefix the name of the scripts with epson_print_conf
+    wrap_script epson_print_conf epson_print_conf
+    wrap_script ui epson_print_conf_ui
+    wrap_script find_printers epson_print_conf_find_printers
+    wrap_script parse_devices epson_print_conf_parse_devices
+  '';
+
+  meta = {
+    description = "Epson Printer Configuration tool and waste ink counter resetter";
+    descriptionLong = ''
+      The Epson Printer Configuration Tool provides an interface for the configuration and monitoring of Epson printers connected via Wi-Fi using the SNMP protocol. A range of features are offered for both end-users and developers.
+
+      The software also includes a configurable printer dictionary, which can be easily extended. In addition, it is possible to import and convert external Epson printer configuration databases.
+    '';
+    homepage = "https://github.com/Ircama/epson_print_conf";
+    license = lib.licenses.eupl12;
+    platforms = lib.platforms.all;
+    mainProgram = "epson_print_conf";
+  };
+})


### PR DESCRIPTION
This PR packages epson_print_conf for Nix with a flake.nix to run it once or install it permanently on a flake system. Some Python dependencies that are missing from nixpkgs are packaged as well. 