### PR TITLE
Add Epson XP-452 / XP-455 printer configuration from devices.xml

### DIFF
--- a/epson_print_conf.py
+++ b/epson_print_conf.py
@@ -614,6 +614,28 @@ class EpsonPrinter:
             },
             "alias": ["XP-235", "XP-433", "XP-435"],
         },
+        "XP-452": {
+            "read_key": [49, 6],
+            "write_key": b"Suramadu",
+            "main_waste": {"oids": [24, 25, 30], "divider": 39.9},
+            "borderless_waste": {"oids": [26, 27, 34], "divider": 32.55},
+            "raw_waste_reset": {
+                24: 0, 25: 0, 30: 0, 28: 0, 29: 0, 46: 94, 26: 0, 27: 0, 34: 0, 47: 94, 49: 0,
+            },
+            "stats": {
+                "Manual cleaning counter": [147],
+                "Timer cleaning counter": [149],
+                "Power cleaning counter": [148],
+                "Total print pass counter": [171, 170, 169, 168],
+                "Total print page counter": [167, 166, 165, 164],
+                "Total scan counter": [471, 470, 469, 468],
+                "First TI received time": [173, 172],
+                "Maintenance required level of 1st waste ink counter": [46],
+                "Maintenance required level of 2nd waste ink counter": [47],
+            },
+            "serial_number": range(192, 202),
+            "alias": ["XP-455"],
+        },
         "XP-540": {
             "read_key": [20, 4],
             "write_key": b"Firmiana",


### PR DESCRIPTION
## Summary

This PR adds support for the Epson XP-452 / XP-455 printer family.

The configuration already exists in `devices.xml`, but it is currently missing from the generated `PRINTER_CONFIG`.

## Changes

- Added `XP-452` configuration.
- Added `XP-455` as alias.
- Uses:
  - read_key `[49, 6]`
  - write_key `b"Suramadu"`

## Testing

Tested successfully on a real Epson XP-455.

Firmware:
MM10I8

Operations verified:

- printer detection
- EEPROM access
- waste ink counter reset

The waste ink counter reset completed successfully and the printer returned to normal operation after reboot.
 


The configuration was generated using:

**python parse_devices.py -m 455 -i**

and then verified by successfully resetting the waste ink counter on a physical Epson XP-455.