### PR TITLE
Fix temporary waste reset and read-key brute force on locked-EEPROM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,15 @@ For the following models there is no known way to read the EEPROM via SNMP proto
 - [EcoTank ET-2862 with firmware 05.18.XF12OB dated 12/11/2024](https://github.com/Ircama/epson_print_conf/discussions/58) and possibly ET-2860 / 2861 / 2863 / 2865 series.
 - [XP-2200 with firmware 06.58.IU05P2](https://github.com/Ircama/epson_print_conf/issues/51)
 
-~~The button "Temporary Reset Waste Ink Levels" should still work with these printers.~~
+The button "Temporary Reset Waste Ink Levels" works with these printers: the `rw`
+command needs only the printer serial number and no read key, and the serial is
+reported in plaintext by the status block even when the EEPROM is locked.
+
+Note that only *SNMP* EEPROM access is disabled on these models. On at least some
+of them the EEPROM remains readable and writable over *USB*, via the IEEE 1284.4
+(D4) `EPSON-CTRL` service, using the same read/write keys; see
+[reinkpy](https://codeberg.org/atufi/reinkpy). A permanent waste-counter reset may
+therefore still be possible on a printer listed above, over a USB cable.
 
 ### Using the command-line tool
 

--- a/epson_print_conf.py
+++ b/epson_print_conf.py
@@ -2469,7 +2469,18 @@ class EpsonPrinter:
         Thanks to https://codeberg.org/atufi/reinkpy/issues/12#issuecomment-1661250
         """
         serial = self.get_serial_number()
-        if not serial:
+        if not serial or "?" in serial:
+            # get_serial_number() reads the serial out of the EEPROM, which is
+            # unavailable on printers whose EEPROM interface is locked by
+            # firmware (e.g. L3250, and every model under "Known incompatible
+            # models"). Those are exactly the printers that depend on this
+            # command. The "rw" command needs only the serial - no read_key -
+            # and the status block reports it in plaintext, so use that rather
+            # than hashing the "?" placeholder and getting back "rw:01:NA;".
+            status = self.get_printer_status() or {}
+            serial = status.get("serial_number_info") or serial
+        if not serial or "?" in serial:
+            logging.error("EpsonPrinter - cannot determine the serial number")
             return None
         sha1 = hashlib.sha1(serial.encode())
         oid = self.epctrl_snmp_oid(
@@ -2672,7 +2683,9 @@ class EpsonPrinter:
         if not self.parm:
             logging.error("EpsonPrinter - invalid API usage")
             return None
-        for x, y in itertools.permutations(range(minimum, maximum + 1), r=2):
+        # product(), not permutations(): permutations() never yields a pair
+        # of equal bytes, so a key such as [7, 7] could never be found.
+        for x, y in itertools.product(range(minimum, maximum + 1), repeat=2):
             self.parm['read_key'] = [x, y]
             logging.warning(f"Trying {self.parm['read_key']}...")
             val = self.read_eeprom(0x00, label="brute_force_read_key")


### PR DESCRIPTION
Two independent bugs, both found while working on an **L3250** (firmware `05.22.XF26P8`), a model listed under *Known incompatible models*.

### 1. `temporary_reset_waste()` could never work on the printers that need it

It sources the serial from `get_serial_number()`, which reads it **out of the EEPROM**. On models whose EEPROM is locked by firmware that read fails, so the `rw` command was sent with the SHA-1 of `None`/`"?"` and the printer replied `rw:01:NA;`.

Those locked models are exactly the ones with no other option which I suspect is why the README note about this button is struck through.

The `rw` command needs **only the serial, no read key**, and the status block reports the serial in plaintext regardless of the EEPROM lock. So fall back to it. On my L3250:

```
get_serial_number()  (EEPROM path) -> None
status serial_number_info          -> 'XATW215133'
temporary_reset_waste(dry_run)     -> True     # was None, returned at the `if not serial` guard
```

and the live command answers `rw:01:OK;`.

### 2. `brute_force_read_key()` cannot find keys made of two equal bytes

`itertools.permutations(r=2)` never yields a pair of equal elements:

```
permutations -> 65280 candidates
product      -> 65536 candidates
```

So 256 keys; every `[n, n]` ;are unreachable, and the function reports failure without having tested them. One-word fix to `itertools.product(repeat=2)`.

### README

Un-strikes the note above, and records something that may be useful to everyone on that list: only **SNMP** EEPROM access is disabled on these models. On at least some of them the EEPROM is still readable *and writable* over **USB**, through the IEEE 1284.4 (D4) `EPSON-CTRL` service, using the same keys and that is how the L3250 above got a permanent waste-counter reset after the SNMP `||` interface refused all 65536 keys.