### PR TITLE
README: Windows note for the USB (D4) route on the L3250/L3251

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ of them the EEPROM remains readable and writable over *USB*, via the IEEE 1284.4
 [reinkpy](https://codeberg.org/atufi/reinkpy). A permanent waste-counter reset may
 therefore still be possible on a printer listed above, over a USB cable.
 
+On Windows, the two reports so far needed no driver replacement (no Zadig).
+On an L3250 with pyusb/libusb, interfaces 0 and 1 could not be claimed but
+interface 2 (class 255, vendor-specific) could, and the Epson driver kept
+working ([#35](https://github.com/Ircama/epson_print_conf/issues/35#issuecomment-5460694144)).
+On an L3251, the D4 channel was opened without libusb through the Windows
+`USBPRINT` device interface, using only the Python standard library
+([epson-l3251-usb-reset](https://github.com/onur-kesim/epson-l3251-usb-reset)).
+Neither report covers other models.
+
 ### Using the command-line tool
 
 ```


### PR DESCRIPTION
Follow-up to #35 and #129.

The README now notes that on the SNMP-locked models the EEPROM may still be reachable over USB (IEEE 1284.4 / D4). This adds one Windows-specific paragraph, because in #35 the Windows setup is what cost hours: in both reports (L3250, L3251) no driver replacement (Zadig) was needed, and on the L3250 the Epson driver kept working.

Both statements come from hardware tests, each linked in the text: endafk on an L3250 through pyusb/libusb (#35), and me on an L3251 through the Windows `USBPRINT` interface with no libusb. Nothing here implies USB support inside epson_print_conf; like the existing reinkpy link, it is a pointer.

Documentation only, no code changes.